### PR TITLE
Adapt wslib to recent refactoring in Server

### DIFF
--- a/wslib-classes/GUI/Extensions/extServer-makeView.sc
+++ b/wslib-classes/GUI/Extensions/extServer-makeView.sc
@@ -356,7 +356,7 @@
 		w.front;
 
 		ctlr = SimpleController(this)
-			.put(\this.serverRunning, {	if(this.serverRunning,running,stopped) })
+			.put(\serverRunning, {	if(this.serverRunning,running,stopped) })
 			.put(\counts,{
 				infoString.string =
 					"%, CPU: %/%S/SD: %/%"

--- a/wslib-classes/GUI/Extensions/extServer-makeView.sc
+++ b/wslib-classes/GUI/Extensions/extServer-makeView.sc
@@ -8,19 +8,19 @@
 		var infoString, oldOnClose;
 		var font;
 		var cpuMeter, composite;
-		
-		
+
+
 		font = Font(Font.defaultSansFace, 10);
 		onColor = onColor ? Color.new255(74, 120, 74);
-		
+
 		if (window.notNil, { ^window.front });
-		
+
 		if(w.isNil,{
-			w = window = GUI.window.new(name.asString ++ " server", 
+			w = window = GUI.window.new(name.asString ++ " server",
 						Rect(10, named.values.indexOf(this) * 120 + 10, 320, 92));
 			w.view.decorator = FlowLayout(w.view.bounds);
 		});
-		
+
 		if(isLocal,{
 			if( useRoundButton )
 				{ booter = RoundButton(w, Rect(0,0, 18, 18)).canFocus_( false );
@@ -30,8 +30,8 @@
 				{ booter = Button( w, Rect(0,0,18,18));
 				 booter.states = [[ "B"],[ "Q", onColor ]];
 				 booter.font = font; };
-						
-			booter.action = { arg view; 
+
+			booter.action = { arg view;
 				if(view.value == 1, {
 					booting.value;
 					this.boot;
@@ -40,30 +40,30 @@
 					this.quit;
 				});
 			};
-			booter.value = serverRunning.binaryValue;
+			booter.value = this.serverRunning.binaryValue;
 		});
-		
+
 		active = StaticText(w, Rect(0,0, 78, 18));
 		active.string = this.name.asString;
 		active.align = \center;
 		active.font = GUI.font.new("Helvetica-Bold", 12);
 		active.background = Color.white;
-		if(serverRunning,running,stopped);	
-		
+		if(this.serverRunning,running,stopped);
+
 		/*
 		w.view.keyDownAction = { arg ascii, char;
 			var startDump, stopDump, stillRunning;
-			
-			case 
+
+			case
 			{char === $n} { this.queryAllNodes }
-			{char === $ } { if(serverRunning.not) { this.boot } }
+			{char === $ } { if(this.serverRunning.not) { this.boot } }
 			{char === $s and: {this.inProcess}} { this.scope }
 			{char == $d} {
 				if(this.isLocal or: { this.inProcess }) {
 					stillRunning = {
 						SystemClock.sched(0.2, { this.stopAliveThread });
 					};
-					startDump = { 
+					startDump = {
 						this.dumpOSC(1);
 						this.stopAliveThread;
 						dumping = true;
@@ -79,13 +79,13 @@
 				} {
 					"cannot dump a remote server's messages".inform
 				}
-			
+
 			};
 		};
 		*/
-		
+
 		if (isLocal, {
-			
+
 			running = {
 				active.stringColor_( onColor );
 				booter.value = 1;
@@ -102,25 +102,25 @@
 				active.stringColor_( Color.new255(255, 140, 0) );
 				//booter.setProperty(\value,0);
 			};
-			
+
 			bundling = {
 				active.stringColor_(Color.new255(237, 157, 196));
 				booter.value = 1;
 				recorder.enabled = false;
 			};
-			
+
 			oldOnClose = w.onClose.copy;
 			w.onClose = {
-			
+
 				//OSCresponder.removeAddr(addr);
 				//this.stopAliveThread;
 				//this.quit;
-				
+
 				oldOnClose.value;
 				window = nil;
 				ctlr.remove;
 			};
-		},{	
+		},{
 			running = {
 				active.background = onColor
 				//recorder.enabled = true;
@@ -134,87 +134,87 @@
 			booting = {
 				active.background = Color.yellow;
 			};
-			
+
 			oldOnClose = w.onClose.copy;
 			w.onClose = {
 				// but do not remove other responders
-				
+
 				oldOnClose.value;
 				this.stopAliveThread;
 				ctlr.remove;
 			};
 		});
-		if(serverRunning,running,stopped);
-			
+		if(this.serverRunning,running,stopped);
+
 		//w.view.decorator;
-		
+
 		composite = CompositeView( w, 200@18 );
-		
+
 			infoString = GUI.staticText.new(composite, Rect(0,0, 200, 18));
 		infoString.string = "CPU: %/%\tSynths/Defs: %/%"			.format( "?", "?", "?", "?" );
 		infoString.font_( font );
-		
+
 		/*
 		cpuMeter = SCLevelIndicator( composite, 192@18 )
 			//.numTicks_( 9 ) // includes 0;
 			//.numMajorTicks_( 5 )
-			
+
 			.drawsPeak_( true )
 			.warning_( 0.8 )
 			.critical_( 1 );
 		*/
-		
-	
-		
+
+
+
 		w.view.decorator.nextLine;
-		
-		
+
+
 		w.front;
 
 		ctlr = SimpleController(this)
-			.put(\serverRunning, {	if(serverRunning,running,stopped) })
+			.put(\this.serverRunning, {	if(this.serverRunning,running,stopped) })
 			.put(\counts,{
-				
+
 				infoString.string =
 					"CPU: %/%\tSynths/Defs: %/%"
-						.format(avgCPU.asStringWithFrac(1),  peakCPU.asStringWithFrac(1), 
-							numSynths, numSynthDefs );
-				
+						.format(this.avgCPU.asStringWithFrac(1),  this.peakCPU.asStringWithFrac(1),
+							this.numSynths, this.numSynthDefs );
+
 				/*
 				infoString.string =
 					"Synths/Defs: %/%"
-						.format( numSynths, numSynthDefs );
+						.format( this.numSynths, this.numSynthDefs );
 				*/
-				
+
 				/*
-				cpuMeter.value = avgCPU / 100;
-				cpuMeter.peakLevel = peakCPU / 100;
+				cpuMeter.value = this.avgCPU / 100;
+				cpuMeter.peakLevel = this.peakCPU / 100;
 				*/
-				
+
 			})
 			.put(\cmdPeriod,{
 				//recorder.setProperty(\value,0);
-			});	
+			});
 		this.startAliveThread;
 	}
-	
+
 /////////////////////////////////////////////
-	
+
 	makeView2 { arg w, useRoundButton = true; // temp
 		var active, booter, killer, makeDefault, running, booting, stopped;
 		var recorder, scoper;
 		var countsViews, ctlr;
 		var dumping=false;
 		var infoString, oldOnClose;
-		
+
 		if (window.notNil, { ^window.front });
-		
+
 		if(w.isNil,{
-			w = window = GUI.window.new(name.asString ++ " server", 
+			w = window = GUI.window.new(name.asString ++ " server",
 						Rect(10, named.values.indexOf(this) * 120 + 10, 300, 92));
 			w.view.decorator = FlowLayout(w.view.bounds);
 		});
-		
+
 		if(isLocal,{
 			if( useRoundButton )
 				{ booter = RoundButton(w, Rect(0,0, 16, 16)).canFocus_( false );
@@ -223,8 +223,8 @@
 			 	}
 				{ booter = GUI.button.new( w, Rect(0,0,16,16));
 				 booter.states = [[ "B"],[ "Q" ]]; };
-						
-			booter.action = { arg view; 
+
+			booter.action = { arg view;
 				if(view.value == 1, {
 					booting.value;
 					this.boot;
@@ -233,35 +233,35 @@
 					this.quit;
 				});
 			};
-			booter.value = serverRunning.binaryValue;
+			booter.value = this.serverRunning.binaryValue;
 			/*
 			killer = SCButton(w, Rect(0,0, 24, 24));
 			killer.states = [["K", Color.black, Color.clear]];
-			
+
 			killer.action = { Server.killAll };
-			*/	
+			*/
 		});
-		
+
 		active = GUI.staticText.new(w, Rect(0,0, 60, 16));
 		active.string = this.name.asString;
 		active.align = \center;
 		active.font = GUI.font.new("Helvetica-Bold", 12);
 		active.background = Color.white;
-		if(serverRunning,running,stopped);		
+		if(this.serverRunning,running,stopped);
 
 		w.view.keyDownAction = { arg ascii, char;
 			var startDump, stopDump, stillRunning;
-			
-			case 
+
+			case
 			{char === $n} { this.queryAllNodes }
-			{char === $ } { if(serverRunning.not) { this.boot } }
+			{char === $ } { if(this.serverRunning.not) { this.boot } }
 			{char === $s and: {this.inProcess}} { this.scope }
 			{char == $d} {
 				if(this.isLocal or: { this.inProcess }) {
 					stillRunning = {
 						SystemClock.sched(0.2, { this.stopAliveThread });
 					};
-					startDump = { 
+					startDump = {
 						this.dumpOSC(1);
 						this.stopAliveThread;
 						dumping = true;
@@ -277,12 +277,12 @@
 				} {
 					"cannot dump a remote server's messages".inform
 				}
-			
+
 			};
 		};
-		
+
 		if (isLocal, {
-			
+
 			running = {
 				active.string_( "running" );
 				active.stringColor_(Color.green);
@@ -302,19 +302,19 @@
 				active.stringColor_(Color.yellow(0.7));
 				//booter.setProperty(\value,0);
 			};
-			
+
 			oldOnClose = w.onClose.copy;
 			w.onClose = {
-			
+
 				//OSCresponder.removeAddr(addr);
 				//this.stopAliveThread;
 				//this.quit;
-				
+
 				oldOnClose.value;
 				window = nil;
 				ctlr.remove;
 			};
-		},{	
+		},{
 			running = {
 				active.string_( "running" );
 				active.background = Color.green;
@@ -331,42 +331,42 @@
 				active.string_( "booting" );
 				active.background = Color.yellow;
 			};
-			
+
 			oldOnClose = w.onClose.copy;
 			w.onClose = {
 				// but do not remove other responders
-				
+
 				oldOnClose.value;
 				this.stopAliveThread;
 				ctlr.remove;
 			};
 		});
-		if(serverRunning,running,stopped);
-			
+		if(this.serverRunning,running,stopped);
+
 		//w.view.decorator;
-		
+
 		infoString = GUI.staticText.new(w, Rect(0,0, 170, 16));
 		infoString.string = "%, CPU: %/%S/SD: %/%"
 			.format( addr.port, "?", "?", "?", "?" );
 		infoString.font_( GUI.font.new( "Monaco", 9 ) );
-		
+
 		w.view.decorator.nextLine;
-		
-		
+
+
 		w.front;
 
 		ctlr = SimpleController(this)
-			.put(\serverRunning, {	if(serverRunning,running,stopped) })
+			.put(\this.serverRunning, {	if(this.serverRunning,running,stopped) })
 			.put(\counts,{
 				infoString.string =
 					"%, CPU: %/%S/SD: %/%"
 						.format( addr.port,
-							avgCPU.round(0.1),  peakCPU.round(0.1), 
-							numSynths, numSynthDefs );
+							this.avgCPU.round(0.1),  this.peakCPU.round(0.1),
+							this.numSynths, this.numSynthDefs );
 			})
 			.put(\cmdPeriod,{
 				//recorder.setProperty(\value,0);
-			});	
+			});
 		this.startAliveThread;
 	}
 


### PR DESCRIPTION
wslib extends Server which has recently been refactored: serverRunning,
avgCPU, peakCPU, numSynths, numSynthDefs have moved to a separate class
ServerStatusWatcher. Within Server new methods under the name of the
previous variables have been added. These have to be prefixed with
'this' when called from within an instance of server.

Additional automatic whitespace cleanup
