### PR TITLE
generatePatternSeqs features

### DIFF
--- a/wslib-classes/Main Features/SimpleMIDIFile/extSimpleMIDIFile-patterns.sc
+++ b/wslib-classes/Main Features/SimpleMIDIFile/extSimpleMIDIFile-patterns.sc
@@ -177,6 +177,11 @@ Note that the first track in a SimpleMIDIFile often contains no note events if i
 				var diff;
 				if (i==0,Ê
 					{	
+						// If first note in MIDI file is not at beginning of file, add a
+						// rest at the beginning of the pattern to fill the empty space.
+						if (event.startPos != 0, {
+							seq.add([\rest, event.startPos]);
+						});
 						seq.add([event.note, event.dur]);
 					},
 					{


### PR DESCRIPTION
Hello,

This introduces 2 features to the `generatePatternSeqs` method, as well as unit tests & MIDI files demonstrating the features.

* Adds an option to parse velocity, and return a 3-tuple instead of a 2-tuple, with the third element a velocity (from 0.0 - 1.0).
* Adds two options to add rests at the beginning and end of the pattern, useful for exporting MIDI files intended to be used as loops.  This is explained further below.

Consider this MIDI file:

![image](https://user-images.githubusercontent.com/94535/92963571-87f36a80-f427-11ea-8db0-eea1264188b0.png)

This would create a pattern like:

```
[
  [48, 1],
  [\rest, 1],
  [48, 1]
]
```

Now consider this MIDI file:

![image](https://user-images.githubusercontent.com/94535/92963787-dd2f7c00-f427-11ea-9ba7-5830e78daf0c.png)

Without this PR, `generatePatternSeqs` will generate the same pattern.  But I want to put a rest in there, useful when loading loops in the MIDI sequence.

By the same token, if the notes in the MIDI file do not go until the end of the file, I'd like to define the length of the loop and to insert a rest.

Unit tests and fixtures (example MIDI files) included.  To run the tests:

```
UnitTest.runTestClassForClass(SimpleMIDIFile);
```


The post window should show:

```
RUNNING UNIT TEST 'TestSimpleMIDIFile'
PASS: a TestSimpleMIDIFile: test_generatePatternSeqs_withVelocity
Is:
         [ [ 60, 1.0, 0.59055118110236 ], [ rest, 1.0, 0.0 ], [ 60, 1.0, 0.78740157480315 ] ]
Should be:
         [ [ 60, 1.0, 0.59055118110236 ], [ rest, 1.0, 0.0 ], [ 60, 1.0, 0.78740157480315 ] ]
PASS: a TestSimpleMIDIFile: test_generatePatternSeqs_noPaddingBeginningStart
Is:
         [ [ 60, 1.0 ], [ rest, 1.0 ], [ 60, 1.0 ] ]
Should be:
         [ [ 60, 1.0 ], [ rest, 1.0 ], [ 60, 1.0 ] ]
PASS: a TestSimpleMIDIFile: test_generatePatternSeqs_noPaddingOffsetStart
Is:
         [ [ 60, 1.0 ], [ rest, 1.0 ], [ 60, 1.0 ] ]
Should be:
         [ [ 60, 1.0 ], [ rest, 1.0 ], [ 60, 1.0 ] ]
PASS: a TestSimpleMIDIFile: test_generatePatternSeqs_padStart
Is:
         [ [ rest, 1.0 ], [ 60, 1.0 ], [ rest, 1.0 ], [ 60, 1.0 ] ]
Should be:
         [ [ rest, 1.0 ], [ 60, 1.0 ], [ rest, 1.0 ], [ 60, 1.0 ] ]
PASS: a TestSimpleMIDIFile: test_generatePatternSeqs_padEnd
Is:
         [ [ 60, 1.0 ], [ rest, 1.0 ], [ 60, 1.0 ], [ rest, 1.0 ] ]
Should be:
         [ [ 60, 1.0 ], [ rest, 1.0 ], [ 60, 1.0 ], [ rest, 1.0 ] ]

UNIT TESTS FOR 'TestSimpleMIDIFile' COMPLETED
There were no failures
```